### PR TITLE
Add 'lh' as binary in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,6 @@
     "require": {
     	"symfony/console": "^4.0",
     	"symfony/dotenv": "^4.0"
-    }
+    },
+    "bin": ["lh"]
 }


### PR DESCRIPTION
This allows users to install the package with `composer global require madeny/lhttps`, once it is published on [packagist](https://packagist.org/). 🙂 