### PR TITLE
Have composer handle the extension requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ from terminal and do the following:
 ```
 
 * ```cd lhttps     ```
-* ```composer install      ``` make sure "dom" and "mbstring" extensions are installed!
+* ```composer install      ``` 
 * ```php lh create domain.com     ```
 
 If you wish to add your rootCA.pem to your Mac OS trusted certificate, use the a flag ```--a``` right after domain.com like so: ```php lh create domain.com --a```

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,8 @@
         "phpunit/phpunit": "^7"
     },
     "require": {
+        "ext-dom": "*",
+        "ext-mbstring": "*",
     	"symfony/console": "^4.0",
     	"symfony/dotenv": "^4.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "526e174f687f51c029becab81a32bcd9",
+    "content-hash": "e9aad6842ca6edf7d0c9eb7a7967c3b2",
     "packages": [
         {
             "name": "symfony/console",
@@ -1652,6 +1652,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "ext-dom": "*",
+        "ext-mbstring": "*"
+    },
     "platform-dev": []
 }


### PR DESCRIPTION
Rather than users having to manually check for extensions, use composer to declare they are required